### PR TITLE
Add support for Gleam syntax in logger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "rollup-plugin-hypothetical": "^2.1.1"
       },
       "devDependencies": {
+        "@types/lz-string": "^1.3.34",
         "@typescript-eslint/eslint-plugin": "^5.8.0",
         "@typescript-eslint/parser": "^5.8.0",
         "copy-webpack-plugin": "^10.0.0",
@@ -567,6 +568,12 @@
       "version": "7.0.9",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
+      "dev": true
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -6959,6 +6966,12 @@
     },
     "@types/json-schema": {
       "version": "7.0.9",
+      "dev": true
+    },
+    "@types/lz-string": {
+      "version": "1.3.34",
+      "resolved": "https://registry.npmjs.org/@types/lz-string/-/lz-string-1.3.34.tgz",
+      "integrity": "sha512-j6G1e8DULJx3ONf6NdR5JiR2ZY3K3PaaqiEuKYkLQO0Czfi1AzrtjfnfCROyWGeDd5IVMKCwsgSmMip9OWijow==",
       "dev": true
     },
     "@types/minimist": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "rollup-plugin-hypothetical": "^2.1.1"
   },
   "devDependencies": {
+    "@types/lz-string": "^1.3.34",
     "@typescript-eslint/eslint-plugin": "^5.8.0",
     "@typescript-eslint/parser": "^5.8.0",
     "copy-webpack-plugin": "^10.0.0",

--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,7 @@ textarea,
   margin-right: 10px;
   margin-bottom: 10px;
   user-select: initial;
+  width: calc(100% - 22px); /* subtract margin and border */
   height: auto !important;
   display: block;
   min-height: 20em;
@@ -134,6 +135,16 @@ body,
   height: calc(100vh - 61px);
 }
 
+/*
+  This ancient magic incantation makes the editors grow and shrink when the browser window
+  is resized or zoomed. 
+
+  See <https://github.com/microsoft/monaco-editor/issues/1482>
+*/
+.monaco-editor {
+  position: absolute;
+}
+
 @media (min-width: 800px) and (min-resolution: 1dppx) {
   .content {
     flex-direction: row;
@@ -212,6 +223,7 @@ body,
   gap: 5px;
   padding-top: 5px;
   padding-bottom: 5px;
+  grid-template: "1 2 3" / 3fr 5fr 3fr;
 }
 
 .btn-group button.active {

--- a/src/index.css
+++ b/src/index.css
@@ -223,7 +223,34 @@ body,
   gap: 5px;
   padding-top: 5px;
   padding-bottom: 5px;
-  grid-template: "1 2 3" / 3fr 5fr 3fr;
+  grid-template: "compile target share" / 3fr 5fr 3fr;
+}
+
+#compile {
+  grid-area: compile;
+}
+
+#target-language-toggle {
+  grid-area: target;
+}
+
+#share {
+  grid-area: share;
+}
+
+@media (max-width: 1000px) {
+  .button-cluster {
+    grid-template:
+      "compile share"
+      "target target" / 1fr 1fr;
+  }
+
+  #target-language-toggle {
+    display: grid;
+    grid-row: 2 / 3;
+    grid-column: 1 / 3;
+    grid-template-columns: subgrid;
+  }
 }
 
 .btn-group button.active {

--- a/src/logging.css
+++ b/src/logging.css
@@ -16,16 +16,16 @@
 }
 
 .log-container .group-header {
-  color: #333;
+  color: #000c;
   font-weight: bold;
 }
 
 .log-container [data-log-level="clear"] {
-  color: #aaa;
+  color: #0005;
 }
 
 .log-container [data-log-level="trace"] {
-  color: #555;
+  color: #000a;
 }
 
 .log-container [data-log-level="warn"] {
@@ -60,11 +60,11 @@
 }
 
 .log-container .undef {
-  color: #777;
+  color: #0008;
 }
 
 .log-container .clear {
-  color: #888;
+  color: #0007;
   font-style: italic;
 }
 
@@ -89,7 +89,7 @@
 .log-container [data-log-level] .object {
   display: inline-flex;
   flex-direction: column;
-  border-left: 2px solid #ccc;
+  border-left: 2px solid #0004;
   padding: 0 5px 0 25px;
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -156,6 +156,7 @@ async function compile() {
 
         logger.clear();
         logger.mountGlobally();
+        logger.showGleamSyntax = true;
 
         if (
           evalResult != undefined &&
@@ -166,7 +167,7 @@ async function compile() {
           } catch (e) {
             if (e.gleam_error) {
               logger.error(
-                `Error: ${e.gleam_error}\n  module: ${e.module}\n  line:`,
+                `Error: ${e.message}\n  module: ${e.module}\n  line:`,
                 e.line,
                 `\n  fn: ${e.fn}\n  value:`,
                 e.value

--- a/src/virtualdom.ts
+++ b/src/virtualdom.ts
@@ -4,7 +4,7 @@ export interface H {
   id?: string;
   attributes?: Record<string, string>;
   on?: Record<string, (e: Event) => boolean | void>;
-  children?: Node;
+  children?: Node | string;
 }
 
 export function frag(...items: (string | Node | H)[]): Node {
@@ -29,7 +29,7 @@ export function frag(...items: (string | Node | H)[]): Node {
   }
 }
 
-export function h(item: H, children?: Node | string): HTMLElement {
+export function h(item: H): HTMLElement {
   const el = document.createElement(item.tag ?? "div");
   if (item.className != null) el.className = item.className;
   if (item.id != null) el.id = item.id;
@@ -46,12 +46,9 @@ export function h(item: H, children?: Node | string): HTMLElement {
   if (item.children != null) {
     el.append(item.children);
   }
-  if (children != null) {
-    el.append(children);
-  }
   return el;
 }
 
 export function styled(cls: string, children: Node | string): Node {
-  return h({ tag: "i", className: cls }, children);
+  return h({ tag: "i", className: cls, children });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,9 @@
   "compilerOptions": {
     "removeComments": true,
     "preserveConstEnums": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "target": "ES2017",
+    "moduleResolution": "Node"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "**/*.spec.ts"]


### PR DESCRIPTION
Fixes #4

Values are now displayed as the equivalent Gleam types in the logger. This affects arrays (tuples), booleans and undefined (Nil):

| JS         | Gleam syntax | 
|--------------|-----------------|
| `[1, 2, 3]` | `#(1, 2, 3)` |
| `true` | `True` |
| `undefined` | `Nil` |

Other types are displayed like in JS. However, objects that appear to be Gleam types also use the equivalent Gleam syntax. To detect Gleam types, the prototypes are inspected:

| JS         | Prototypes | Gleam syntax |
|--------------|-----------------|----------------|
| `{ "0": 5, foo: "bar" }` | `MyType -> CustomType` | `MyType(5, foo: "bar")` |
| <pre>{ head: 5,<br>  tail: { head: 3,<br>          tail: {} } }</pre> | <pre>NonEmpty -> List<br>NonEmpty -> List<br>Empty -> List</pre> | <pre>[5, 3]</pre> |

Gleam syntax can be enabled and disabled at runtime, but there's isn't a button yet to control it.

Note that even when Gleam syntax is enabled, the JS properties of objects can still be inspected by clicking on the arrow next to an object.

-----

This PR increases the TypeScript `target` from ES3 to ES2017. This may result in smaller and more efficient JS being emitted, and enables features such as accessors, which are unavailable when targeting ES3. Increasing the target to ES2017 is ok because no browser older than 2017 can possibly support WebAssembly.

This PR also includes some layout/design changes:

* Editors correctly adjust their size when zooming in or making the browser window smaller
* The buttons above the Gleam editor are in a single row again
* Colors in the logger were adjusted to look better on red background