### PR TITLE
bugfix javascript button toggle, clear output on each build run

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
               <h2>Result</h2>
             </div>
             <!-- prettier-ignore -->
-            <div id="eval-output" class="editor"><div data-log-level="clear" class="placeholder">Output...</div></div>
+            <div id="eval-output" class="editor"><div data-log-level="clear" class="placeholder">Output…</div></div>
           </div>
           <div class="compiled-output">
             <div id="javascript-output" class="output-panel">

--- a/src/main.ts
+++ b/src/main.ts
@@ -183,6 +183,7 @@ async function compile() {
     } else {
       erlangEditor.setValue(files.Ok["build/dev/erlang/gleam-wasm/main.erl"]);
 
+      logger.clear();
       logger.log(
         "Compiled successfully!\n\nNote that the Erlang target is not executable in the browser."
       );
@@ -208,18 +209,26 @@ document.getElementById("share").addEventListener("click", async (_event) => {
   notyf.success("Link copied to clipboard!");
 });
 
-document
-  .getElementById("target-erlang")
-  .addEventListener("click", async (_event) => {
-    target = TargetLanguage.Erlang;
-    document.getElementById("target-erlang").classList.toggle("active");
-    document.getElementById("target-javascript").classList.toggle("active");
+document.querySelectorAll(".toggle-button").forEach((elem) => {
+  elem.addEventListener("click", async (event) => {
+    const elem = event.currentTarget as HTMLInputElement;
+    if (elem.id === "target-javascript") {
+      target = TargetLanguage.JavaScript;
+    } else if (elem.id === "target-erlang") {
+      target = TargetLanguage.Erlang;
+    }
 
-    document.getElementById("target-erlang").setAttribute("disabled", "");
-    document.getElementById("target-javascript").removeAttribute("disabled");
+    document.getElementById("target-javascript").classList.toggle("active");
+    document.getElementById("target-erlang").classList.toggle("active");
+
+    (<HTMLInputElement>document.getElementById("target-javascript")).disabled =
+      !document.getElementById("target-javascript");
+    (<HTMLInputElement>document.getElementById("target-erlang")).disabled =
+      !document.getElementById("target-erlang");
 
     targetChanged();
   });
+});
 
 function targetChanged() {
   document.getElementById("javascript-output").classList.toggle("hidden");
@@ -231,5 +240,6 @@ function targetChanged() {
     document.querySelector("#compile nobr").textContent = "Build";
   }
 
-  document.getElementById("eval-output").textContent = "";
+  document.getElementById("eval-output").innerHTML =
+    '<div data-log-level="clear" class="placeholder">Output…</div>';
 }


### PR DESCRIPTION
* Fix: Toggling Erlang works but toggling back to Javascript does not work on <https://johndoneth.github.io/gleam-playground/>
* Also cleared the output window for each build run.