### PR TITLE
Add support for bitstrings in logger

### DIFF
--- a/src/logging.css
+++ b/src/logging.css
@@ -96,14 +96,25 @@
 /* stylelint-disable-next-line no-descending-specificity */
 .log-container button {
   border: none;
+  border-radius: 3px;
   margin: -2px 0;
-  padding: 0;
+  padding: 0 5px;
   display: inline-block;
   height: 20px;
   min-width: 20px;
   text-align: center;
   background-color: transparent;
   letter-spacing: 0.02em;
+}
+
+.log-container button:hover {
+  background-color: #f073;
+  outline: none;
+}
+
+.log-container button:focus {
+  box-shadow: inset 0 0 0 2px #f073;
+  outline: none;
 }
 
 .log-container .expand {
@@ -113,6 +124,7 @@
 .log-container button.arrow-button {
   font-size: 110%;
   margin-left: -20px;
+  padding: 0;
 }
 
 .log-container .object > .expand {

--- a/src/virtualdom.ts
+++ b/src/virtualdom.ts
@@ -49,6 +49,13 @@ export function h(item: H): HTMLElement {
   return el;
 }
 
-export function styled(cls: string, children: Node | string): Node {
+export function styled(cls: string, children: Node | string): Element {
   return h({ tag: "i", className: cls, children });
+}
+
+export function button(
+  content: Node | string,
+  action: (e: MouseEvent) => void
+): Element {
+  return h({ tag: "button", on: { click: action }, children: content });
 }


### PR DESCRIPTION
The bytes can be displayed either as hexadecimal numbers or as UTF-8 string. There's a button to switch between the two.

Try it with

```rs
pub fn main() {
  <<"hello world":utf8>>
}
```